### PR TITLE
Update RE in Lexer for floats and integers

### DIFF
--- a/Compiler/src/gpLexer.lex
+++ b/Compiler/src/gpLexer.lex
@@ -98,8 +98,8 @@ extern int parse_target;
           				        "string.\n", yylineno);                   
                                    return 0; }  
 
-[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?. { yylval.dnum = atof(yytext); return DNUM; } 
-[0-9]+              { yylval.num = atoi(yytext); return NUM; } 
+[-+]?[0-9]*\.[0-9]+([eE][-+]?[0-9]+)? { yylval.dnum = atof(yytext); return DNUM; } 
+[-+]?[0-9]+              { yylval.num = atoi(yytext); return NUM; } 
 
  /* GP2 keywords */ 
 Main		    return MAIN;


### PR DESCRIPTION
As noted to Chris, the previous version of the RE for floats had some errors in it.
Numbers are used to denote positions of nodes, which are discarded by the parser anyway. They are created and used by the graphical editor.