### PR TITLE
Fix rules and conditions containing the "any" mark

### DIFF
--- a/Compiler/src/genCondition.c
+++ b/Compiler/src/genCondition.c
@@ -249,7 +249,7 @@ static void generatePredicateCode(Rule *rule, Predicate *predicate)
                  }
                  item = item->next;
               }
-              PTFI("int host_edge_index = lookupEdge(morphism, %d);\n", 3, index);
+              PTFI("int host_edge_index = lookupEdge(morphism, %d);\n", 9, index);
               generateLabelEvaluationCode(predicate->edge_pred.label, false, list_count++, 1, 9);
               PTFI("if(equalHostLabels(label, edge->label))\n", 9);
               PTFI("{\n", 9);

--- a/Compiler/src/genCondition.c
+++ b/Compiler/src/genCondition.c
@@ -249,6 +249,7 @@ static void generatePredicateCode(Rule *rule, Predicate *predicate)
                  }
                  item = item->next;
               }
+              PTFI("int host_edge_index = lookupEdge(morphism, %d);\n", 3, index);
               generateLabelEvaluationCode(predicate->edge_pred.label, false, list_count++, 1, 9);
               PTFI("if(equalHostLabels(label, edge->label))\n", 9);
               PTFI("{\n", 9);
@@ -291,6 +292,7 @@ static void generatePredicateCode(Rule *rule, Predicate *predicate)
            }
            else
            {
+              PTFI("int host_edge_index = lookupEdge(morphism, %d);\n", 3, index);
               generateLabelEvaluationCode(left_label, false, list_count++, 2, 3);
               generateLabelEvaluationCode(right_label, false, list_count++, 3, 3);
               PTFI("if(", 3);

--- a/Compiler/src/genRule.c
+++ b/Compiler/src/genRule.c
@@ -793,7 +793,11 @@ void generateAddRHSCode(Rule *rule)
             blank_label = true;
          }
       }
-      else generateLabelEvaluationCode(node->label, true, index, 0, 3);
+      else
+      {
+         PTFI("int host_edge_index = lookupEdge(morphism, %d);\n", 3, index);
+         generateLabelEvaluationCode(node->label, true, index, 0, 3);
+      }
       PTFI("int node_array_size%d = host->nodes.size;\n", 3, index);
       PTFI("index = addNode(host, %d, label);\n", 3, node->root);
       if(rule->adds_edges) PTFI("map[%d] = index;\n", 3, node->index);
@@ -814,7 +818,11 @@ void generateAddRHSCode(Rule *rule)
             blank_label = true;
          }
       }
-      else generateLabelEvaluationCode(edge->label, false, index, 0, 3);
+      else
+      {
+         PTFI("int host_edge_index = lookupEdge(morphism, %d);\n", 3, index);
+         generateLabelEvaluationCode(edge->label, false, index, 0, 3);
+      }
       /* The host-source and host-target of added edges are taken from the 
        * map populated in the previous loop. */
       PTFI("int edge_array_size%d = host->edges.size;\n", 3, index);


### PR DESCRIPTION
Rules and conditions containing the `any` mark would cause invalid code to be generated, due to `generateLabelEvaluationCode` sometimes being called when the declaration for `host_edge_index` had not been generated.

This PR just generates the declaration before each faulty call to the function.