### PR TITLE
Disallow any in RHS edges not exclusively incident to interface nodes

### DIFF
--- a/Compiler/src/seman.c
+++ b/Compiler/src/seman.c
@@ -697,6 +697,23 @@ void graphScan(GPRule *rule, List *interface, string scope, string rule_name, ch
        * edges and fewer LHS wildcard edges. I think. */
       if(wildcard && side == 'r')
       {
+         bool source_in_interface, target_in_interface = false;
+         List *iterator = interface;
+         while(iterator != NULL)  
+         {
+            if(!strcmp(source_id, iterator->node_id))
+               source_in_interface = true;
+            if(!strcmp(target_id, iterator->node_id))
+               target_in_interface = true;
+            iterator = iterator->next;
+         }
+         if(!source_in_interface || !target_in_interface) 
+         {
+            print_error("Error (%s): Wildcard edge %s in %s graph not exclusively "
+                        "incident to interface nodes.\n", rule_name, edge_id, graph_type);
+            abort_compilation = true;  
+         }
+
          symbol = symbol_list;
          while(symbol) 
          {


### PR DESCRIPTION
Instead of failing with an aborted assumption at runtime, we should prevent this at compile time.

---

Consider the following program:

```
Main = rule

rule(x, y: list)
[ (n0, x) | (e0, n0, n0, y # any) ]
=>
[ (n0, x) | (e0, n0, n0, y # any) ]
interface={}
```

with input graph:

```
[ (0, 6) | (0, 0, 0, 42 # dashed) ]
```

Previously, it would fail, at run-time, with:

```
gp2run: graph.c:393: getEdge: Assertion `index < graph->edges.size' failed.
```

Now it fails, at compile-time,  with:

```
Error (Main_rule): Wildcard edge e0 in RHS graph not exclusively incident to interface nodes.
Program /data/programs/match-edge-any-no-interface is invalid. Build aborted.
```
